### PR TITLE
Fixed typo in Polish translation

### DIFF
--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -124,7 +124,7 @@
     <string name="minutely_overview">Minutowa prognoza</string>
     <string name="precipitation_overview">Prognoza opadów</string>
     <string name="air_quality">Jakość powietrza</string>
-    <string name="allergen">Alergrny</string>
+    <string name="allergen">Alergeny</string>
     <string name="life_details">Szczegóły</string>
     <string name="sunrise_sunset">Słońce i księżyc</string>
 


### PR DESCRIPTION
`Alergrny` -> `Alergeny`